### PR TITLE
Changed the namespace of the dbcontext file

### DIFF
--- a/CommodityTradingAPI/CommodityTradingAPI/Data/CommodotiesDbContext.cs
+++ b/CommodityTradingAPI/CommodityTradingAPI/Data/CommodotiesDbContext.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using CommodityTradingAPI.Models;
 using Microsoft.EntityFrameworkCore;
 
-namespace New.Namespace;
+namespace CommodityTradingAPI.Data;
 
 public partial class CommodotiesDbContext : DbContext
 {


### PR DESCRIPTION
Dbcontext namespace had a default value, so I changed it to "CommodityTradingAPI.Data" so that it can be easily referenced in controllers.